### PR TITLE
TSS-18004: Fix consecutive double quotes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,7 @@
  <!-- PROPERTIES -->
  <property file='build-custom.properties' />
  
- <property name='version'   value='20190610.1'/>
+ <property name='version'   value='20190610.2'/>
  <property name='name'      value='owasp-java-html-sanitizer'/>
  <property name='fullname'  value='${name}-${version}'/>
  <property name='Title'     value='OWASP Java HTML Sanitizer'/>

--- a/src/main/java/org/owasp/html/HtmlLexer.java
+++ b/src/main/java/org/owasp/html/HtmlLexer.java
@@ -388,10 +388,18 @@ final class HtmlInputSplitter extends AbstractTokenStream {
       } else if ('"' == ch || '\'' == ch) {
         type = HtmlTokenType.QSTRING;
         int delim = ch;
+        boolean space = true;
         for (; end < limit; ++end) {
           if (input.charAt(end) == delim) {
             ++end;
             break;
+          } else {
+            int nextChar = input.charAt(end);
+            if (nextChar == '>' && space) {
+              break;
+            } else if (!Character.isWhitespace(nextChar)) {
+              space = false;
+            }
           }
         }
       } else if (!Character.isWhitespace(ch)) {


### PR DESCRIPTION
Unit test: 

        `String html="<html><body><h1 style=\"background-color:powderblue;\" \" > This is a heading</h1></body></html>"`
        `String html="<html><body><h1 style=\"background-color:powderblue;\"    \" > This is a heading</h1></body></html>"`
Before the fix it gives blank output and after the fix it prints.  "This is a heading "


I am adding the changes here however we need to change build process and moving custom changes to fork instead of maintain the  folder as a repo. 

I will file a ticket. 

https://files.zimbra.com/repository/owasp-java-html-sanitizer/owasp-java-html-sanitizer-20190610.2z.jar 