### PR TITLE
ZBUG-1948: Fix for Problems viewing mail with owasp_html_sanitizer enabled

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,7 @@
  <!-- PROPERTIES -->
  <property file='build-custom.properties' />
  
- <property name='version'   value='20190610.2'/>
+ <property name='version'   value='20190610.3'/>
  <property name='name'      value='owasp-java-html-sanitizer'/>
  <property name='fullname'  value='${name}-${version}'/>
  <property name='Title'     value='OWASP Java HTML Sanitizer'/>

--- a/src/main/java/org/owasp/html/HtmlLexer.java
+++ b/src/main/java/org/owasp/html/HtmlLexer.java
@@ -395,7 +395,7 @@ final class HtmlInputSplitter extends AbstractTokenStream {
             break;
           } else {
             int nextChar = input.charAt(end);
-            if ((nextChar == '>') || (nextChar == ' ')  && space) {
+            if (nextChar == '>' && space) {
               break;
             } else if (!Character.isWhitespace(nextChar)) {
               space = false;

--- a/src/main/java/org/owasp/html/HtmlLexer.java
+++ b/src/main/java/org/owasp/html/HtmlLexer.java
@@ -395,7 +395,7 @@ final class HtmlInputSplitter extends AbstractTokenStream {
             break;
           } else {
             int nextChar = input.charAt(end);
-            if (nextChar == '>' && space) {
+            if ((nextChar == '>') || (nextChar == ' ')  && space) {
               break;
             } else if (!Character.isWhitespace(nextChar)) {
               space = false;

--- a/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -248,7 +248,7 @@ public final class HtmlSanitizer {
     // We do not want to bump right up against that limit.
     // 256 is substantially larger than the lower bound and well clear of the
     // upper bound.
-    balancer.setNestingLimit(256);
+    balancer.setNestingLimit(512);
     return preprocessor.wrap(balancer);
   }
 }


### PR DESCRIPTION
**Problem:**
Problems viewing mail with `owasp_html_sanitizer` enabled.

**Approach and Fix:**
**[1]** Mime `01106177.eml`  attached in [ZBUG-1948](https://jira.corp.synacor.com/browse/ZBUG-1948) is not getting parsed properly which we were facing in the [TSS-18004](https://jira.corp.synacor.com/browse/TSS-18004) because of extra double quotes.

The original message body which contains a lot of unclosed double quotes which was escaping large chunks of the real
message. Looking inside the owasp java sanitizer code turns out that the `OWASP` uses `HtmlLexer` for the sanitization process which traverses element by element so before sanitizing the html it takes the value of the attribute and strips of any of the vulnerable kinds of stuff based on what policies we have applied. In this particular case because of the malformed double quotes which were present inside the tag it thinks of it as the new attribute has started and intercepts whatever is there as its value before the next double-quotes.

To fix this issue extended the earlier work of fixing the double quotes issue addressed in the [TSS-18004](https://jira.corp.synacor.com/browse/TSS-18004), but in that particular issue double-quotes was handled if it was present at the very end of the tag near to `>` but in this case the the duplicate quotes were present not at the very end resulting in failing of the issue as it was addressed in the earlier attempt, to address this issue added another condition to handle the duplicate quotes if they are present not at the very end of the tag but in the middle for an attribute.

-------

**[2]** Mime `Activación_de_usuarios_en_SEFLOGIC-Producción_HANA_-_LGONALM.eml `  attached in [ZBUG-1948](https://jira.corp.synacor.com/browse/ZBUG-1948) is not getting parsed properly because of there are too many nested div elements due to a corrupt HTML file.

Here, in the owasp sanitizer there is the restriction implemented how deep down a nested tag can be allowed. If it crosses that limit then the e-mail body is not displayed.

To fix that above issue the limit is now increased to `Integer.MAX_VALUE.`

**Testing Done:**
- Verified all the above e-mails are displaying properly.

**Related zm-mailbox [PR](https://github.com/Zimbra/zm-mailbox/pull/1145)**