### PR TITLE
ZBUG-2547 externsisble HtmlStreamRenderer

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,7 @@
  <!-- PROPERTIES -->
  <property file='build-custom.properties' />
  
- <property name='version'   value='20190610.4'/>
+ <property name='version'   value='20190610.5'/>
  <property name='name'      value='owasp-java-html-sanitizer'/>
  <property name='fullname'  value='${name}-${version}'/>
  <property name='Title'     value='OWASP Java HTML Sanitizer'/>

--- a/src/main/java/org/owasp/html/AutoCloseableExtensibleHtmlStreamRenderer.java
+++ b/src/main/java/org/owasp/html/AutoCloseableExtensibleHtmlStreamRenderer.java
@@ -1,0 +1,128 @@
+// Copyright (c) 2011, Mike Samuel
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// Neither the name of the OWASP nor the names of its contributors may
+// be used to endorse or promote products derived from this software
+// without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package org.owasp.html;
+
+import javax.annotation.WillCloseWhenClosed;
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+/**
+ * Access main file here:
+ * https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/blob/develop/src/main/java/org/owasp/html/AutoCloseableHtmlStreamRenderer.java
+ */
+final class AutoCloseableExtensibleHtmlStreamRenderer extends ExtensibleHtmlStreamRenderer
+        // This is available on JDK6 and makes this class extend AutoCloseable.
+        implements Closeable {
+    private final Object closeable;
+
+    private static final Class<?> CLASS_AUTO_CLOSEABLE;
+
+    static {
+        Class<?> classAutoCloseable = null;
+        for (Class<?> superInterface : Closeable.class.getInterfaces()) {
+            if ("java.lang.AutoCloseable".equals(superInterface.getName())) {
+                classAutoCloseable = superInterface;
+                break;
+            }
+        }
+        CLASS_AUTO_CLOSEABLE = classAutoCloseable;
+    }
+
+    private static final Method METHOD_CLOSE;
+
+    static {
+        Method methodClose = null;
+        if (CLASS_AUTO_CLOSEABLE != null) {
+            try {
+                methodClose = CLASS_AUTO_CLOSEABLE.getMethod("close");
+            } catch (NoSuchMethodException ex) {
+                throw (NoSuchMethodError) new NoSuchMethodError().initCause(ex);
+            }
+        }
+        METHOD_CLOSE = methodClose;
+    }
+
+    static boolean isAutoCloseable(Object o) {
+        return o instanceof Closeable || CLASS_AUTO_CLOSEABLE != null && CLASS_AUTO_CLOSEABLE.isInstance(o);
+    }
+
+    // ZBUG-2547 change to accept zimbra_strict_unclosed_comment_tag and
+    // zimbra_strict_unclosed_comment_tag local config value
+    static AutoCloseableExtensibleHtmlStreamRenderer createAutoCloseableHtmlStreamRenderer(
+            @WillCloseWhenClosed Appendable output, Handler<? super IOException> errorHandler,
+            Handler<? super String> badHtmlHandler, boolean strictUnclosedCDATACheck,
+            Set<String> skipTagsUnclosedCdata) {
+        return new AutoCloseableExtensibleHtmlStreamRenderer(output, errorHandler, badHtmlHandler,
+                strictUnclosedCDATACheck, skipTagsUnclosedCdata);
+    }
+
+    // ZBUG-2547 change to accept zimbra_strict_unclosed_comment_tag and
+    // zimbra_strict_unclosed_comment_tag local config value
+    private AutoCloseableExtensibleHtmlStreamRenderer(@WillCloseWhenClosed Appendable output,
+            Handler<? super IOException> errorHandler, Handler<? super String> badHtmlHandler,
+            boolean strictUnclosedCDATACheck, Set<String> skipTagsUnclosedCdata) {
+        super(output, errorHandler, badHtmlHandler, strictUnclosedCDATACheck, skipTagsUnclosedCdata);
+        this.closeable = output;
+    }
+
+    private static final Object[] ZERO_OBJECTS = new Object[0];
+
+    public void close() throws IOException {
+        if (isDocumentOpen()) {
+            closeDocument();
+        }
+        closeIfAnyCloseable(closeable);
+    }
+
+    static void closeIfAnyCloseable(Object closeable) throws IOException {
+        if (closeable instanceof Closeable) {
+            ((Closeable) closeable).close();
+        } else if (METHOD_CLOSE != null) {
+            try {
+                METHOD_CLOSE.invoke(closeable, ZERO_OBJECTS);
+            } catch (IllegalAccessException ex) {
+                AssertionError ae = new AssertionError("close not public");
+                ae.initCause(ex);
+                throw ae;
+            } catch (InvocationTargetException ex) {
+                Throwable tgt = ex.getTargetException();
+                if (tgt instanceof IOException) {
+                    throw (IOException) tgt;
+                } else if (tgt instanceof RuntimeException) {
+                    throw (RuntimeException) tgt;
+                } else {
+                    throw new AssertionError(null, tgt);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/owasp/html/ExtensibleHtmlStreamRenderer.java
+++ b/src/main/java/org/owasp/html/ExtensibleHtmlStreamRenderer.java
@@ -1,0 +1,509 @@
+// Copyright (c) 2011, Mike Samuel
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// Neither the name of the OWASP nor the names of its contributors may
+// be used to endorse or promote products derived from this software
+// without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package org.owasp.html;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import javax.annotation.WillCloseWhenClosed;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Given a series of HTML tokens, writes valid, normalized HTML to the output.
+ * The output will have well-defined tag boundaries, but there may be orphaned
+ * or missing close and open tags. The result of two renderers can always be
+ * concatenated to produce a larger snippet of HTML, but if the first was called
+ * with {@code writeOpenTag("plaintext", ...)}, then any tags in the second will
+ * not be interpreted as tags in the concatenated version.
+ * 
+ * Access main file here :
+ * https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/blob/develop/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+ */
+@TCB
+@NotThreadSafe
+public class ExtensibleHtmlStreamRenderer implements HtmlStreamEventReceiver {
+
+    private boolean strictUnclosedCDATACheck;
+    private Set<String> skipTagsUnclosedCdata;
+
+    private final Appendable output;
+    private final Handler<? super IOException> ioExHandler;
+    private final Handler<? super String> badHtmlHandler;
+    private String lastTagOpened;
+    private StringBuilder pendingUnescaped;
+    private HtmlTextEscapingMode escapingMode = HtmlTextEscapingMode.PCDATA;
+    private boolean open;
+
+    /**
+     * Factory.
+     * 
+     * @param output         the buffer to which HTML is streamed.
+     * @param ioExHandler    called with any exception raised by output.
+     * @param badHtmlHandler receives alerts when HTML cannot be rendered because
+     *                       there is not valid HTML tree that results from that
+     *                       series of calls. E.g. it is not possible to create an
+     *                       HTML {@code <style>} element whose textual content is
+     *                       {@code "</style>"}.
+     */
+    public static ExtensibleHtmlStreamRenderer create(@WillCloseWhenClosed Appendable output,
+            Handler<? super IOException> ioExHandler, Handler<? super String> badHtmlHandler) {
+        boolean strict = false;
+        Set<String> defaultSkipTags = new HashSet<>(Arrays.asList("style"));
+        if (output instanceof Closeable) {
+            return new CloseableHtmlStreamRenderer(output, ioExHandler, badHtmlHandler, strict, defaultSkipTags);
+        } else if (AutoCloseableExtensibleHtmlStreamRenderer.isAutoCloseable(output)) {
+            return AutoCloseableExtensibleHtmlStreamRenderer.createAutoCloseableHtmlStreamRenderer(output, ioExHandler,
+                    badHtmlHandler, strict, defaultSkipTags);
+        } else {
+            return new ExtensibleHtmlStreamRenderer(output, ioExHandler, badHtmlHandler, strict, defaultSkipTags);
+        }
+    }
+
+    // ZBUG-2547 change to accept zimbra_strict_unclosed_comment_tag and
+    // zimbra_strict_unclosed_comment_tag local config value
+    public static ExtensibleHtmlStreamRenderer create(@WillCloseWhenClosed Appendable output,
+            Handler<? super IOException> ioExHandler, Handler<? super String> badHtmlHandler,
+            boolean strictUnclosedCDATACheck, Set<String> skipTagsUnclosedCdata) {
+        if (output instanceof Closeable) {
+            return new CloseableHtmlStreamRenderer(output, ioExHandler, badHtmlHandler, strictUnclosedCDATACheck,
+                    skipTagsUnclosedCdata);
+        } else if (AutoCloseableExtensibleHtmlStreamRenderer.isAutoCloseable(output)) {
+            return AutoCloseableExtensibleHtmlStreamRenderer.createAutoCloseableHtmlStreamRenderer(output, ioExHandler,
+                    badHtmlHandler, strictUnclosedCDATACheck, skipTagsUnclosedCdata);
+        } else {
+            return new ExtensibleHtmlStreamRenderer(output, ioExHandler, badHtmlHandler, strictUnclosedCDATACheck,
+                    skipTagsUnclosedCdata);
+        }
+    }
+
+    /**
+     * Factory.
+     * 
+     * @param output         the buffer to which HTML is streamed.
+     * @param badHtmlHandler receives alerts when HTML cannot be rendered because
+     *                       there is not valid HTML tree that results from that
+     *                       series of calls. E.g. it is not possible to create an
+     *                       HTML {@code <style>} element whose textual content is
+     *                       {@code "</style>"}.
+     */
+    public static ExtensibleHtmlStreamRenderer create(StringBuilder output, Handler<? super String> badHtmlHandler) {
+        // Propagate since StringBuilder should not throw IOExceptions.
+        return create(output, Handler.PROPAGATE, badHtmlHandler);
+    }
+
+    // ZBUG-2547 change to accept zimbra_strict_unclosed_comment_tag and
+    // zimbra_strict_unclosed_comment_tag local config value
+    protected ExtensibleHtmlStreamRenderer(Appendable output, Handler<? super IOException> ioExHandler,
+            Handler<? super String> badHtmlHandler, boolean strictUnclosedCDATACheck,
+            Set<String> skipTagsUnclosedCdata) {
+        this.output = output;
+        this.ioExHandler = ioExHandler;
+        this.badHtmlHandler = badHtmlHandler;
+        this.strictUnclosedCDATACheck = strictUnclosedCDATACheck;
+        this.skipTagsUnclosedCdata = skipTagsUnclosedCdata;
+    }
+
+    /**
+     * Called when the series of calls make no sense. May be overridden to throw an
+     * unchecked throwable, to log, or to take some other action.
+     *
+     * @param message    for human consumption.
+     * @param identifier an HTML identifier associated with the message.
+     */
+    protected void error(String message, CharSequence identifier) {
+        if (badHtmlHandler != Handler.DO_NOTHING) { // Avoid string append.
+            badHtmlHandler.handle(message + " : " + identifier);
+        }
+    }
+
+    public void openDocument() throws IllegalStateException {
+        if (open) {
+            throw new IllegalStateException();
+        }
+        open = true;
+    }
+
+    public void closeDocument() throws IllegalStateException {
+        if (!open) {
+            throw new IllegalStateException();
+        }
+        if (pendingUnescaped != null) {
+            closeTag(lastTagOpened);
+        }
+        open = false;
+        if (output instanceof Flushable) {
+            try {
+                ((Flushable) output).flush();
+            } catch (IOException ex) {
+                ioExHandler.handle(ex);
+            }
+        }
+    }
+
+    /**
+     * True if {@link #openDocument()} has been called and {@link #closeDocument()}
+     * has not subsequently been called.
+     */
+    protected boolean isDocumentOpen() {
+        return open;
+    }
+
+    public void openTag(String elementName, List<String> attrs) {
+        try {
+            writeOpenTag(elementName, attrs);
+        } catch (IOException ex) {
+            ioExHandler.handle(ex);
+        }
+    }
+
+    protected void writeOpenTag(String unsafeElementName, List<? extends String> attrs) throws IOException {
+        if (!open) {
+            throw new IllegalStateException();
+        }
+        String elementName = safeName(unsafeElementName);
+        if (!isValidHtmlName(elementName)) {
+            error("Invalid element name", elementName);
+            return;
+        }
+        if (pendingUnescaped != null) {
+            error("Tag content cannot appear inside CDATA element", elementName);
+            return;
+        }
+
+        escapingMode = HtmlTextEscapingMode.getModeForTag(elementName);
+
+        switch (escapingMode) {
+        case CDATA_SOMETIMES:
+        case CDATA:
+        case PLAIN_TEXT:
+            lastTagOpened = elementName;
+            pendingUnescaped = new StringBuilder();
+            break;
+        default:
+            break;
+        }
+
+        output.append('<').append(elementName);
+
+        for (Iterator<? extends String> attrIt = attrs.iterator(); attrIt.hasNext();) {
+            String name = attrIt.next();
+            String value = attrIt.next();
+            name = HtmlLexer.canonicalAttributeName(name);
+            if (!isValidHtmlName(name)) {
+                error("Invalid attr name", name);
+                continue;
+            }
+            output.append(' ').append(name).append('=').append('"');
+            Encoding.encodeHtmlAttribOnto(value, output);
+            if (value.indexOf('`') != -1) {
+                // Apparently, in quirks mode, IE8 does a poor job producing innerHTML
+                // values. Given
+                // <div attr="``foo=bar">
+                // we encode &#96; but if JavaScript does:
+                // nodeA.innerHTML = nodeB.innerHTML;
+                // and nodeB contains the DIV above, then IE8 will produce
+                // <div attr=``foo=bar>
+                // as the value of nodeB.innerHTML and assign it to nodeA.
+                // IE8's HTML parser treats `` as a blank attribute value and foo=bar
+                // becomes a separate attribute.
+                // Adding a space at the end of the attribute prevents this by forcing
+                // IE8 to put double quotes around the attribute when computing
+                // nodeB.innerHTML.
+                output.append(' ');
+            }
+            output.append('"');
+        }
+
+        // Limit our output to the intersection of valid XML and valid HTML5 when
+        // the output contains no special HTML5 elements like <title>, <script>, or
+        // <textarea>.
+        if (HtmlTextEscapingMode.isVoidElement(elementName)) {
+            output.append(" /");
+        }
+
+        output.append('>');
+    }
+
+    public void closeTag(String elementName) {
+        try {
+            writeCloseTag(safeName(elementName));
+        } catch (IOException ex) {
+            ioExHandler.handle(ex);
+        }
+    }
+
+    protected void writeCloseTag(String uncanonElementName) throws IOException {
+        if (!open) {
+            throw new IllegalStateException();
+        }
+        String elementName = HtmlLexer.canonicalElementName(uncanonElementName);
+        if (!isValidHtmlName(elementName)) {
+            error("Invalid element name", elementName);
+            return;
+        }
+
+        if (pendingUnescaped != null) {
+            if (!lastTagOpened.equals(elementName)) {
+                error("Tag content cannot appear inside CDATA element", elementName);
+                return;
+            } else {
+                StringBuilder cdataContent = pendingUnescaped;
+                pendingUnescaped = null;
+                Encoding.stripBannedCodeunits(cdataContent);
+                int problemIndex = checkHtmlCdataCloseable(lastTagOpened, cdataContent);
+                if (problemIndex == -1) {
+                    if (cdataContent.length() != 0) {
+                        output.append(cdataContent);
+                    }
+                } /*
+                   * ZBUG-2547 : We have strictUnclosedCDATACheck retrieved from LC, if it is set
+                   * to true(default value) and problemIndex!=-1 , we end up getting error and
+                   * mail isn't displayed properly(seen blank in ZWC)
+                   *
+                   * When strictUnclosedCDATACheck is set to false , means we relax the rule and
+                   * even if any HTML tag has improper comment tag i.e. without closing tag we
+                   * don't throw error and bypass the problematic tag and email is rendered
+                   * properly in UI
+                   */
+                else {
+                    if (strictUnclosedCDATACheck) {
+                        error("Invalid CDATA text content", cdataContent.subSequence(problemIndex,
+                                Math.min(problemIndex + 10, cdataContent.length())));
+                        // Still output the close tag.
+                    } else if (cdataContent.length() != 0 && !skipTagsUnclosedCdata.contains(uncanonElementName)) {
+                        output.append(cdataContent);
+                    }
+                }
+            }
+            if ("plaintext".equals(elementName)) {
+                return;
+            }
+        }
+        output.append("</").append(elementName).append(">");
+    }
+
+    public void text(String text) {
+        try {
+            writeText(text);
+        } catch (IOException ex) {
+            ioExHandler.handle(ex);
+        }
+    }
+
+    protected void writeText(String text) throws IOException {
+        if (!open) {
+            throw new IllegalStateException();
+        }
+        if (pendingUnescaped != null) {
+            pendingUnescaped.append(text);
+        } else {
+            if (this.escapingMode == HtmlTextEscapingMode.RCDATA) {
+                Encoding.encodeRcdataOnto(text, output);
+            } else {
+                Encoding.encodePcdataOnto(text, output);
+            }
+        }
+    }
+
+    protected static int checkHtmlCdataCloseable(String localName, StringBuilder sb) {
+        // www.w3.org/TR/html51/semantics-scripting.html#restrictions-for-contents-of-script-elements
+        // www.w3.org/TR/html5/scripting-1.html#restrictions-for-contents-of-script-elements
+        // 4.12.1.3. Restrictions for contents of script elements
+        // The textContent of a script element must match the script production in the
+        // following ABNF, the character set for which is Unicode. [ABNF]
+        //
+        // script = outer *( comment-open inner comment-close outer )
+        //
+        // outer = < any string that doesn’t contain a substring that matches
+        // not-in-outer >
+        // not-in-outer = comment-open
+        // inner = < any string that doesn’t contain a substring that matches
+        // not-in-inner >
+        // not-in-inner = comment-close / script-open
+        //
+        // comment-open = "<!--"
+        // comment-close = "-->"
+        // script-open = "<" s c r i p t tag-end
+
+        // We apply the above restrictions to all CDATA (modulo local name).
+        int innerStart = -1;
+        for (int i = 0, n = sb.length(); i < n; ++i) {
+            char ch = sb.charAt(i);
+            switch (ch) {
+            case '<':
+                if (i + 3 < n && sb.charAt(i + 1) == '!') {
+                    if (sb.charAt(i + 2) == '-' && sb.charAt(i + 3) == '-') {
+                        if (innerStart >= 0) {
+                            return i;
+                        } // Nesting
+                        innerStart = i;
+                    }
+                } else { // Look for embedded <script or </script
+                    int start = i + 1;
+                    if (start + 1 < n && sb.charAt(start) == '/') {
+                        ++start;
+                    } else if (innerStart < 0) {
+                        break;
+                    }
+                    // We don't need to do any suffix checks to preserve concatenation safety
+                    // since we buffer pending unescaped above.
+                    int end = start + localName.length();
+                    if (end <= n && Strings.regionMatchesIgnoreCase(sb, start, localName, 0, end - start)
+                            && (end == n || isTagEnd(sb.charAt(end)))) {
+                        return i;
+                    }
+                }
+                break;
+            case '>':
+                if (i >= 2 && sb.charAt(i - 2) == '-' && sb.charAt(i - 2) == '-') {
+                    if (innerStart < 0) {
+                        return i - 2;
+                    }
+                    // Merged start and end like <!--->
+                    if (innerStart + 6 > i) {
+                        return innerStart;
+                    }
+                    innerStart = -1;
+                }
+                break;
+            default:
+                break;
+            }
+        }
+        return innerStart;
+    }
+
+    @VisibleForTesting
+    static boolean isValidHtmlName(String name) {
+        int n = name.length();
+        if (n == 0) {
+            return false;
+        }
+        if (n > 128) {
+            return false;
+        }
+        boolean isNamespaced = false;
+        for (int i = 0; i < n; ++i) {
+            char ch = name.charAt(i);
+            switch (ch) {
+            case ':':
+                if (isNamespaced) {
+                    return false;
+                }
+                isNamespaced = true;
+                if (i == 0 || i + 1 == n) {
+                    return false;
+                }
+                break;
+            case '-':
+            case '_':
+                if (i == 0 || i + 1 == n) {
+                    return false;
+                }
+                break;
+            default:
+                if (ch <= '9') {
+                    if (i == 0 || ch < '0') {
+                        return false;
+                    }
+                } else if ('A' <= ch && ch <= 'z') {
+                    if ('Z' < ch && ch < 'a') {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+                break;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Canonicalizes the element name and possibly substitutes an alternative that
+     * has more consistent semantics.
+     */
+    static String safeName(String unsafeElementName) {
+        String elementName = HtmlLexer.canonicalElementName(unsafeElementName);
+
+        // Substitute a reliably non-raw-text element for raw-text and
+        // plain-text elements.
+        switch (elementName.length()) {
+        case 3:
+            if ("xmp".equals(elementName)) {
+                return "pre";
+            }
+            break;
+        case 7:
+            if ("listing".equals(elementName)) {
+                return "pre";
+            }
+            break;
+        case 9:
+            if ("plaintext".equals(elementName)) {
+                return "pre";
+            }
+            break;
+        }
+        return elementName;
+    }
+
+    static class CloseableHtmlStreamRenderer extends ExtensibleHtmlStreamRenderer implements Closeable {
+        private final Closeable closeable;
+
+        CloseableHtmlStreamRenderer(@WillCloseWhenClosed Appendable output, Handler<? super IOException> errorHandler,
+                Handler<? super String> badHtmlHandler, boolean strictUnclosedCDATACheck,
+                Set<String> skipTagsUnclosedCdata) {
+            super(output, errorHandler, badHtmlHandler, strictUnclosedCDATACheck, skipTagsUnclosedCdata);
+            this.closeable = (Closeable) output;
+        }
+
+        public void close() throws IOException {
+            if (isDocumentOpen()) {
+                closeDocument();
+            }
+            closeable.close();
+        }
+    }
+
+    protected static long TAG_ENDS = 0L | (1L << '\t') | (1L << '\n') | (1L << '\f') | (1L << '\r') | (1L << ' ')
+            | (1L << '/') | (1L << '>');
+
+    protected static boolean isTagEnd(char ch) {
+        return ch < 63 && 0 != (TAG_ENDS & (1L << ch));
+    }
+
+}

--- a/src/test/java/org/owasp/html/ExtensibleHtmlStreamRendererTest.java
+++ b/src/test/java/org/owasp/html/ExtensibleHtmlStreamRendererTest.java
@@ -1,0 +1,382 @@
+// Copyright (c) 2011, Mike Samuel
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// Neither the name of the OWASP nor the names of its contributors may
+// be used to endorse or promote products derived from this software
+// without specific prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package org.owasp.html;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import junit.framework.TestCase;
+
+@SuppressWarnings("javadoc")
+public class ExtensibleHtmlStreamRendererTest extends TestCase {
+
+    private final List<String> errors = Lists.newArrayList();
+    private final StringBuilder rendered = new StringBuilder();
+
+    // when zimbra_strict_unclosed_comment_tag = false , then improper div is
+    // skipped
+    private final ExtensibleHtmlStreamRenderer rendererStrictUnclosedCommentTagFalse = ExtensibleHtmlStreamRenderer
+            .create(rendered, new Handler<Throwable>() {
+                public void handle(Throwable th) {
+                    List<String> errors = ExtensibleHtmlStreamRendererTest.this.errors;
+                    errors.add(th.toString());
+                }
+
+            }, new Handler<String>() {
+                public void handle(String errorMessage) {
+                    @SuppressWarnings({ "hiding", "synthetic-access" })
+                    List<String> errors = ExtensibleHtmlStreamRendererTest.this.errors;
+                    errors.add(errorMessage);
+                }
+            }, false, new HashSet<>(Arrays.asList("script")));
+
+    // when zimbra_strict_unclosed_comment_tag = true , then as per logic error is
+    // thrown
+    private final ExtensibleHtmlStreamRenderer rendererStrictUnclosedCommentTagTrue = ExtensibleHtmlStreamRenderer
+            .create(rendered, new Handler<Throwable>() {
+                public void handle(Throwable th) {
+                    List<String> errors = ExtensibleHtmlStreamRendererTest.this.errors;
+                    errors.add(th.toString());
+                }
+
+            }, new Handler<String>() {
+                public void handle(String errorMessage) {
+                    @SuppressWarnings({ "hiding", "synthetic-access" })
+                    List<String> errors = ExtensibleHtmlStreamRendererTest.this.errors;
+                    errors.add(errorMessage);
+                }
+            }, true, new HashSet<>(Arrays.asList("script")));
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        errors.clear();
+        rendered.setLength(0);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        assertTrue(errors.toString(), errors.isEmpty()); // Catch any tests that don't check errors.
+    }
+
+    public final void testIllegalElementName() throws Exception {
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag(":svg", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.openTag("svg:", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.openTag("-1", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.openTag("svg::svg", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.openTag("a@b", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        String output = rendered.toString();
+        assertFalse(output, output.contains("<"));
+
+        assertEquals(
+                Joiner.on('\n').join("Invalid element name : :svg", "Invalid element name : svg:",
+                        "Invalid element name : -1", "Invalid element name : svg::svg", "Invalid element name : a@b"),
+                Joiner.on('\n').join(errors));
+        errors.clear();
+    }
+
+    public final void testIllegalAttributeName() throws Exception {
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag("div", ImmutableList.of(":svg", "x"));
+        rendererStrictUnclosedCommentTagFalse.openTag("div", ImmutableList.of("svg:", "x"));
+        rendererStrictUnclosedCommentTagFalse.openTag("div", ImmutableList.of("-1", "x"));
+        rendererStrictUnclosedCommentTagFalse.openTag("div", ImmutableList.of("svg::svg", "x"));
+        rendererStrictUnclosedCommentTagFalse.openTag("div", ImmutableList.of("a@b", "x"));
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        String output = rendered.toString();
+        assertFalse(output, output.contains("="));
+
+        assertEquals(Joiner.on('\n').join("Invalid attr name : :svg", "Invalid attr name : svg:",
+                "Invalid attr name : -1", "Invalid attr name : svg::svg", "Invalid attr name : a@b"),
+                Joiner.on('\n').join(errors));
+        errors.clear();
+    }
+
+    public final void testCdataContainsEndTag1() throws Exception {
+        rendererStrictUnclosedCommentTagTrue.openDocument();
+        rendererStrictUnclosedCommentTagTrue.openTag("script", ImmutableList.of("type", "text/javascript"));
+        rendererStrictUnclosedCommentTagTrue.text("document.write('<SCRIPT>alert(42)</SCRIPT>')");
+        rendererStrictUnclosedCommentTagTrue.closeTag("script");
+        rendererStrictUnclosedCommentTagTrue.closeDocument();
+
+        assertEquals("<script type=\"text/javascript\"></script>", rendered.toString());
+        assertEquals("Invalid CDATA text content : </SCRIPT>'", Joiner.on('\n').join(errors));
+        errors.clear();
+    }
+
+    public final void testCdataContainsEndTag2() throws Exception {
+        rendererStrictUnclosedCommentTagTrue.openDocument();
+        rendererStrictUnclosedCommentTagTrue.openTag("style", ImmutableList.of("type", "text/css"));
+        rendererStrictUnclosedCommentTagTrue.text("/* </St");
+        // Split into two text chunks, and insert NULs.
+        rendererStrictUnclosedCommentTagTrue.text("\0yle> */");
+        rendererStrictUnclosedCommentTagTrue.closeTag("style");
+        rendererStrictUnclosedCommentTagTrue.closeDocument();
+
+        assertEquals("<style type=\"text/css\"></style>", rendered.toString());
+        assertEquals("Invalid CDATA text content : </Style> *", Joiner.on('\n').join(errors));
+        errors.clear();
+    }
+
+    public final void testRcdataContainsEndTag() throws Exception {
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag("textarea", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text("<textarea></textarea>");
+        rendererStrictUnclosedCommentTagFalse.closeTag("textarea");
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        assertEquals("<textarea>&lt;textarea&gt;&lt;/textarea&gt;</textarea>", rendered.toString());
+    }
+
+    public final void testHtml51SemanticsScriptingExample5Part1() throws Exception {
+        String js = "  var example = 'Consider this string: <!-- <script>';\n" + "  console.log(example);\n";
+
+        rendererStrictUnclosedCommentTagTrue.openDocument();
+        rendererStrictUnclosedCommentTagTrue.openTag("script", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagTrue.text(js);
+        rendererStrictUnclosedCommentTagTrue.closeTag("script");
+        rendererStrictUnclosedCommentTagTrue.closeDocument();
+
+        assertEquals("Invalid CDATA text content : <script>';", Joiner.on('\n').join(errors));
+        errors.clear();
+    }
+
+    public final void testHtml51SemanticsScriptingExample5Part2() throws Exception {
+        String js = "if (x<!--y) { ... }\n";
+
+        rendererStrictUnclosedCommentTagTrue.openDocument();
+        rendererStrictUnclosedCommentTagTrue.openTag("script", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagTrue.text(js);
+        rendererStrictUnclosedCommentTagTrue.closeTag("script");
+        rendererStrictUnclosedCommentTagTrue.closeDocument();
+
+        assertEquals("<script></script>", rendered.toString());
+        assertEquals("Invalid CDATA text content : <!--y) { .", Joiner.on('\n').join(errors));
+        errors.clear();
+    }
+
+    public final void testMoreUnbalancedHtmlCommentsInScripts() throws Exception {
+        String js = "if (x-->y) { ... }\n";
+
+        rendererStrictUnclosedCommentTagTrue.openDocument();
+        rendererStrictUnclosedCommentTagTrue.openTag("script", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagTrue.text(js);
+        rendererStrictUnclosedCommentTagTrue.closeTag("script");
+        rendererStrictUnclosedCommentTagTrue.closeDocument();
+
+        // We could actually allow this since --> is not banned per 4.12.1.3
+        assertEquals("<script></script>", rendered.toString());
+        assertEquals("Invalid CDATA text content : -->y) { ..", Joiner.on('\n').join(errors));
+        errors.clear();
+    }
+
+    public final void testShortHtmlCommentInScript() throws Exception {
+        String js = "// <!----> <!--->";
+
+        rendererStrictUnclosedCommentTagTrue.openDocument();
+        rendererStrictUnclosedCommentTagTrue.openTag("script", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagTrue.text(js);
+        rendererStrictUnclosedCommentTagTrue.closeTag("script");
+        rendererStrictUnclosedCommentTagTrue.closeDocument();
+
+        // We could actually allow this since --> is not banned per 4.12.1.3
+        assertEquals("<script></script>", rendered.toString());
+        assertEquals("Invalid CDATA text content : <!--->", Joiner.on('\n').join(errors));
+        errors.clear();
+    }
+
+    public final void testHtml51SemanticsScriptingExample5Part3() throws Exception {
+        String js = "<!-- if ( player<script ) { ... } -->";
+
+        rendererStrictUnclosedCommentTagTrue.openDocument();
+        rendererStrictUnclosedCommentTagTrue.openTag("script", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagTrue.text(js);
+        rendererStrictUnclosedCommentTagTrue.closeTag("script");
+        rendererStrictUnclosedCommentTagTrue.closeDocument();
+
+        assertEquals("<script></script>", rendered.toString());
+        assertEquals("Invalid CDATA text content : <script ) ", Joiner.on('\n').join(errors));
+        errors.clear();
+    }
+
+    public final void testHtml51SemanticsScriptingExample5Part4() throws Exception {
+        String js = "<!--\n" + "if (x < !--y) { ... }\n" + "if (!--y > x) { ... }\n" + "if (!(--y) > x) { ... }\n"
+                + "if (player < script) { ... }\n" + "if (script > player) { ... }\n" + "-->";
+
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag("script", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text(js);
+        rendererStrictUnclosedCommentTagFalse.closeTag("script");
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        assertEquals(
+                "<script><!--\n" + "if (x < !--y) { ... }\n" + "if (!--y > x) { ... }\n" + "if (!(--y) > x) { ... }\n"
+                        + "if (player < script) { ... }\n" + "if (script > player) { ... }\n" + "--></script>",
+                rendered.toString());
+    }
+
+    public final void testHtmlCommentInRcdata() throws Exception {
+        String str = "// <!----> <!---> <!--";
+
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag("title", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text(str);
+        rendererStrictUnclosedCommentTagFalse.closeTag("title");
+        rendererStrictUnclosedCommentTagFalse.openTag("textarea", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text(str);
+        rendererStrictUnclosedCommentTagFalse.closeTag("textarea");
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        assertEquals("<title>// &lt;!----&gt; &lt;!---&gt; &lt;!--</title>"
+                + "<textarea>// &lt;!----&gt; &lt;!---&gt; &lt;!--</textarea>", rendered.toString());
+    }
+
+    public final void testTagInCdata() throws Exception {
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag("script", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text("alert('");
+        rendererStrictUnclosedCommentTagFalse.openTag("b", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text("foo");
+        rendererStrictUnclosedCommentTagFalse.closeTag("b");
+        rendererStrictUnclosedCommentTagFalse.text("')");
+        rendererStrictUnclosedCommentTagFalse.closeTag("script");
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        assertEquals("<script>alert('foo')</script>", rendered.toString());
+        assertEquals(Joiner.on('\n').join("Tag content cannot appear inside CDATA element : b",
+                "Tag content cannot appear inside CDATA element : b"), Joiner.on('\n').join(errors));
+        errors.clear();
+    }
+
+    public final void testUnclosedEscapingTextSpan() throws Exception {
+        rendererStrictUnclosedCommentTagTrue.openDocument();
+        rendererStrictUnclosedCommentTagTrue.openTag("script", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagTrue.text("<!--alert('</script>')");
+        rendererStrictUnclosedCommentTagTrue.closeTag("script");
+        rendererStrictUnclosedCommentTagTrue.closeDocument();
+
+        assertEquals("<script></script>", rendered.toString());
+        assertEquals("Invalid CDATA text content : </script>'", Joiner.on('\n').join(errors));
+        errors.clear();
+    }
+
+    public final void testAlmostCompleteEndTag() throws Exception {
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag("script", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text("//</scrip");
+        rendererStrictUnclosedCommentTagFalse.closeTag("script");
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        assertEquals("<script>//</scrip</script>", rendered.toString());
+    }
+
+    public final void testBalancedCommentInNoscript() throws Exception {
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag("noscript", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text("<!--<script>foo</script>-->");
+        rendererStrictUnclosedCommentTagFalse.closeTag("noscript");
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        assertEquals("<noscript>&lt;!--&lt;script&gt;foo&lt;/script&gt;--&gt;</noscript>", rendered.toString());
+    }
+
+    public final void testUnbalancedCommentInNoscript() throws Exception {
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag("noscript", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text("<!--<script>foo</script>--");
+        rendererStrictUnclosedCommentTagFalse.closeTag("noscript");
+        rendererStrictUnclosedCommentTagFalse.openTag("noscript", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text("<script>foo</script>-->");
+        rendererStrictUnclosedCommentTagFalse.closeTag("noscript");
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        assertEquals("<noscript>&lt;!--&lt;script&gt;foo&lt;/script&gt;--</noscript>"
+                + "<noscript>&lt;script&gt;foo&lt;/script&gt;--&gt;</noscript>", rendered.toString());
+    }
+
+    public final void testSupplementaryCodepoints() throws Exception {
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.text("\uD87E\uDC1A"); // Supplementary codepoint U+2F81A
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        assertEquals("&#x2f81a;", rendered.toString());
+    }
+
+    // Test that policies that naively allow <xmp>, <listing>, or <plaintext>
+    // on XHTML don't shoot themselves in the foot.
+
+    public final void testPreSubstitutes1() throws Exception {
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag("Xmp", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text("<form>Hello, World</form>");
+        rendererStrictUnclosedCommentTagFalse.closeTag("Xmp");
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        assertEquals("<pre>&lt;form&gt;Hello, World&lt;/form&gt;</pre>", rendered.toString());
+    }
+
+    public final void testPreSubstitutes2() throws Exception {
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag("xmp", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text("<form>Hello, World</form>");
+        rendererStrictUnclosedCommentTagFalse.closeTag("xmp");
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        assertEquals("<pre>&lt;form&gt;Hello, World&lt;/form&gt;</pre>", rendered.toString());
+    }
+
+    public final void testPreSubstitutes3() throws Exception {
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag("LISTING", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text("<form>Hello, World</form>");
+        rendererStrictUnclosedCommentTagFalse.closeTag("LISTING");
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        assertEquals("<pre>&lt;form&gt;Hello, World&lt;/form&gt;</pre>", rendered.toString());
+    }
+
+    public final void testPreSubstitutes4() throws Exception {
+        rendererStrictUnclosedCommentTagFalse.openDocument();
+        rendererStrictUnclosedCommentTagFalse.openTag("plaintext", ImmutableList.<String>of());
+        rendererStrictUnclosedCommentTagFalse.text("<form>Hello, World</form>");
+        rendererStrictUnclosedCommentTagFalse.closeDocument();
+
+        assertEquals("<pre>&lt;form&gt;Hello, World&lt;/form&gt;", rendered.toString());
+    }
+}


### PR DESCRIPTION
Problem: When zimbra_use_owasp_html_sanitizer=true, then email wasn't showing up in web client

Issue: The issue was because when zimbra_use_owasp_html_sanitizer=true, OWASP sanitizes email i.e. tries to check all the opening comment tags and closing comment tags are closed. If either is being missed then it errors out email isn't formed properly and we don't see email content in ZWC

Solution: After discussion, we came to a point i.e. in HTML if there is any opening tag without a closing tag then we have included 2 local config 
zimbra_strict_unclosed_comment_tag = false
zimbra_skip_tags_unclosed_Cdata = style

If first is set to false, then there won't be strict checking for close tag and also zimbra_skip_tags_unclosed_Cdata is set to style(suspicious tag) we ignore it from rendering it in HTML

Scenarios and testing:
case1: Include some javascript code(I added calculator code) in mime && OWASP is false
--> In inspect the same code in the browser and "<!--" is seen. Although the chrome browser is smart enough to not render in email but shows up in Inspect tab.

case 2 : Include some javascript code(I added calculator code) in mime && OWASP is TRUE && Code modified to handle invalid scenario
--> In Inspect, the invalid tag is not visible and javascript code is not rendered when the closing tag is invalid. Hence we made is secure from vulnerabilities

Case 3: if anything is passed inside comment, OWASP set to true and zimbra_strict_unclosed_comment_tag = false
--> Email renders without throwing error

Case 3: if anything is passed inside comment, OWASP set to true and zimbra_strict_unclosed_comment_tag =true
--> Email has an issue and we expect strict checking for suspicious tags hence it fails to throw error and email doesn't show up

The available mimes of 2547 and 2478 show up properly when LC is set accordingly
zmmailbox PR: https://github.com/Zimbra/zm-mailbox/pull/1404

Original files below :
https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/blob/develop/src/main/java/org/owasp/html/HtmlStreamRenderer.java
https://github.com/Zimbra/java-html-sanitizer-release-20190610.1/blob/develop/src/main/java/org/owasp/html/HtmlStreamRenderer.java