### PR TITLE
Hotfix/zbug 3867

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,7 @@
  <!-- PROPERTIES -->
  <property file='build-custom.properties' />
  
- <property name='version'   value='20190610.5'/>
+ <property name='version'   value='20190610.6'/>
  <property name='name'      value='owasp-java-html-sanitizer'/>
  <property name='fullname'  value='${name}-${version}'/>
  <property name='Title'     value='OWASP Java HTML Sanitizer'/>

--- a/src/main/java/org/owasp/html/Encoding.java
+++ b/src/main/java/org/owasp/html/Encoding.java
@@ -43,6 +43,18 @@ public final class Encoding {
    * @return text/plain
    */
   public static String decodeHtml(String s) {
+    return decodeHtml(s, false);
+  }
+
+  /**
+   * Decodes HTML entities to produce a string containing only valid
+   * Unicode scalar values.
+   *
+   * @param s text/html
+   * @param inAttribute is s in an attribute value?
+   * @return text/plain
+   */
+  public static String decodeHtml(String s, boolean inAttribute) {
     int firstAmp = s.indexOf('&');
     int safeLimit = longestPrefixOfGoodCodeunits(s);
     if ((firstAmp & safeLimit) < 0) { return s; }
@@ -55,7 +67,7 @@ public final class Encoding {
       int amp = firstAmp;
       while (amp >= 0) {
         sb.append(s, pos, amp);
-        int end = HtmlEntities.appendDecodedEntity(s, amp, n, sb);
+        int end = HtmlEntities.appendDecodedEntity(s, amp, n, inAttribute, sb);
         pos = end;
         amp = s.indexOf('&', end);
       }

--- a/src/main/java/org/owasp/html/HtmlEntities.java
+++ b/src/main/java/org/owasp/html/HtmlEntities.java
@@ -2309,7 +2309,23 @@ final class HtmlEntities {
    * @return The offset after the end of the decoded sequence in {@code html}.
    */
   public static int appendDecodedEntity(
-      String html, int offset, int limit, StringBuilder sb) {
+          String html, int offset, int limit, StringBuilder sb) {
+    return appendDecodedEntity(html, offset, limit, false, sb);
+  }
+
+  /**
+   * Decodes any HTML entity at the given location and appends it to a string
+   * builder.  This handles both named and numeric entities.
+   *
+   * @param html HTML text.
+   * @param offset the position of the sequence to decode in {@code html}.
+   * @param limit the last position that could be part of the sequence to decode
+   *    in {@code html}.
+   * @param sb string builder to append to.
+   * @return The offset after the end of the decoded sequence in {@code html}.
+   */
+  public static int appendDecodedEntity(
+          String html, int offset, int limit, boolean inAttribute, StringBuilder sb) {
     char ch = html.charAt(offset);
     if ('&' != ch) {
       sb.append(ch);
@@ -2422,7 +2438,7 @@ final class HtmlEntities {
         char nameChar = html.charAt(i);
         t = t.lookup(nameChar);
         if (t == null) { break; }
-        if (t.isTerminal()) {
+        if (t.isTerminal() && mayComplete(inAttribute, html, i, limit)) {
           longestDecode = t;
           tail = i + 1;
         }
@@ -2434,7 +2450,7 @@ final class HtmlEntities {
           if ('Z' >= nameChar && nameChar >= 'A') { nameChar |= 32; }
           t = t.lookup(nameChar);
           if (t == null) { break; }
-          if (t.isTerminal()) {
+          if (t.isTerminal() && mayComplete(inAttribute, html, i, limit)) {
             longestDecode = t;
             tail = i + 1;
           }
@@ -2456,10 +2472,36 @@ final class HtmlEntities {
 
   private static boolean isHtmlIdContinueChar(char ch) {
     int chLower = ch | 32;
-    return ('0' <= chLower && chLower <= '9')
+    return ('0' <= ch && ch <= '9')
             || ('a' <= chLower && chLower <= 'z')
             || ('-' == ch);
   }
+
+
+  /** True if the character at i in html may complete a named character reference */
+  private static boolean mayComplete(boolean inAttribute, String html, int i, int limit) {
+    if (inAttribute && html.charAt(i) != ';' && i + 1 < limit) {
+      // See if the next character blocks treating this as a full match.
+      // This avoids problems like "&para" being treated as a decoding in
+      //     <a href="?foo&param=1">
+      if (continuesCharacterReferenceName(html.charAt(i + 1))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * @see <a href="https://github.com/OWASP/java-html-sanitizer/issues/254#issuecomment-1080864368"
+   * >comments in issue 254</a>
+   */
+  private static boolean continuesCharacterReferenceName(char ch) {
+    int chLower = ch | 32;
+    return ('0' <= ch && ch <= '9')
+            || ('a' <= chLower && chLower <= 'z')
+            || (ch == '=');
+  }
+
 
 //  /** A possible entity name like "amp" or "gt". */
 //  public static boolean isEntityName(String name) {

--- a/src/main/java/org/owasp/html/HtmlSanitizer.java
+++ b/src/main/java/org/owasp/html/HtmlSanitizer.java
@@ -144,7 +144,7 @@ public final class HtmlSanitizer {
       switch (token.type) {
         case TEXT:
           receiver.text(
-              Encoding.decodeHtml(htmlContent.substring(token.start, token.end)));
+              Encoding.decodeHtml(htmlContent.substring(token.start, token.end), false));
           break;
         case UNESCAPED:
           receiver.text(Encoding.stripBannedCodeunits(
@@ -177,8 +177,9 @@ public final class HtmlSanitizer {
                       htmlContent.substring(tagBodyToken.start, tagBodyToken.end)));
                   break;
                 case ATTRVALUE:
-                  attrs.add(Encoding.decodeHtml(stripQuotes(
-                      htmlContent.substring(tagBodyToken.start, tagBodyToken.end))));
+                  String attributeContentRaw =
+                          stripQuotes(htmlContent.substring(tagBodyToken.start, tagBodyToken.end));
+                  attrs.add(Encoding.decodeHtml(attributeContentRaw, true));
                   attrsReadyForName = true;
                   break;
                 case TAGEND:

--- a/src/test/java/org/owasp/html/EncodingTest.java
+++ b/src/test/java/org/owasp/html/EncodingTest.java
@@ -34,6 +34,24 @@ import junit.framework.TestCase;
 
 @SuppressWarnings("javadoc")
 public final class EncodingTest extends TestCase {
+  private static void assertDecodedHtml(String want, String inputHtml) {
+    assertDecodedHtml(want, want, inputHtml);
+  }
+
+  private static void assertDecodedHtml(
+          String wantText, String wantAttr, String inputHtml
+  ) {
+    assertEquals(
+            "!inAttribute: " + inputHtml,
+            wantText,
+            Encoding.decodeHtml(inputHtml, false)
+    );
+    assertEquals(
+            "inAttribute: " + inputHtml,
+            wantAttr,
+            Encoding.decodeHtml(inputHtml, true)
+    );
+  }
 
   @Test
   public static final void testDecodeHtml() {
@@ -43,170 +61,90 @@ public final class EncodingTest extends TestCase {
     // 123456789012345678901234567890123456789012345678901234567890123456789
     String golden =
       "The quick\u00a0brown fox\njumps over\r\nthe lazy dog\n";
-    assertEquals(golden, Encoding.decodeHtml(html));
+    assertDecodedHtml(golden, html);
 
     // Don't allocate a new string when no entities.
-    assertSame(golden, Encoding.decodeHtml(golden));
+    assertSame(golden, golden);
 
     // test interrupted escapes and escapes at end of file handled gracefully
-    assertEquals(
-        "\\\\u000a",
-        Encoding.decodeHtml("\\\\u000a"));
-    assertEquals(
-        "\n",
-        Encoding.decodeHtml("&#x000a;"));
-    assertEquals(
-        "\n",
-        Encoding.decodeHtml("&#x00a;"));
-    assertEquals(
-        "\n",
-        Encoding.decodeHtml("&#x0a;"));
-    assertEquals(
-        "\n",
-        Encoding.decodeHtml("&#xa;"));
-    assertEquals(
+    assertDecodedHtml("\\\\u000a", "\\\\u000a");
+    assertDecodedHtml("\n", "&#x000a;");
+    assertDecodedHtml("\n", "&#x00a;");
+    assertDecodedHtml("\n", "&#x0a;");
+    assertDecodedHtml("\n", "&#xa;");
+    assertDecodedHtml(
         String.valueOf(Character.toChars(0x10000)),
-        Encoding.decodeHtml("&#x10000;"));
-    assertEquals(
-        "\n",
-        Encoding.decodeHtml("&#xa"));
-    assertEquals(
-        "&#x00ziggy",
-        Encoding.decodeHtml("&#x00ziggy"));
-    assertEquals(
-        "&#xa00z;",
-        Encoding.decodeHtml("&#xa00z;"));
-    assertEquals(
-        "&#\n",
-        Encoding.decodeHtml("&#&#x000a;"));
-    assertEquals(
-        "&#x\n",
-        Encoding.decodeHtml("&#x&#x000a;"));
-    assertEquals(
-        "\n\n",
-        Encoding.decodeHtml("&#xa&#x000a;"));
-    assertEquals(
-        "&#\n",
-        Encoding.decodeHtml("&#&#xa;"));
-    assertEquals(
-        "&#x",
-        Encoding.decodeHtml("&#x"));
-    assertEquals(
-        "",  // NUL elided.
-        Encoding.decodeHtml("&#x0"));
-    assertEquals(
-        "&#",
-        Encoding.decodeHtml("&#"));
+            "&#x10000;"
+    );
+    assertDecodedHtml("\n", "&#xa");
+    assertDecodedHtml("&#x00ziggy", "&#x00ziggy");
+    assertDecodedHtml("&#xa00z;", "&#xa00z;");
+    assertDecodedHtml("&#\n", "&#&#x000a;");
+    assertDecodedHtml("&#x\n", "&#x&#x000a;");
+    assertDecodedHtml("\n\n", "&#xa&#x000a;");
+    assertDecodedHtml("&#\n", "&#&#xa;");
+    assertDecodedHtml("&#x", "&#x");
+    assertDecodedHtml("", "&#x0"); // NUL elided.
+    assertDecodedHtml("&#", "&#");
 
-    assertEquals(
-        "\\",
-        Encoding.decodeHtml("\\"));
-    assertEquals(
-        "&",
-        Encoding.decodeHtml("&"));
+    assertDecodedHtml("\\", "\\");
+    assertDecodedHtml("&", "&");
 
-    assertEquals(
-        "&#000a;",
-        Encoding.decodeHtml("&#000a;"));
-    assertEquals(
-        "\n",
-        Encoding.decodeHtml("&#10;"));
-    assertEquals(
-        "\n",
-        Encoding.decodeHtml("&#010;"));
-    assertEquals(
-        "\n",
-        Encoding.decodeHtml("&#0010;"));
-    assertEquals(
-        "\t",
-        Encoding.decodeHtml("&#9;"));
-    assertEquals(
-        "\n",
-        Encoding.decodeHtml("&#10"));
-    assertEquals(
-        "&#00ziggy",
-        Encoding.decodeHtml("&#00ziggy"));
-    assertEquals(
-        "&#\n",
-        Encoding.decodeHtml("&#&#010;"));
-    assertEquals(
-        "\n",
-        Encoding.decodeHtml("&#0&#010;"));
-    assertEquals(
-        "\n",
-        Encoding.decodeHtml("&#01&#10;"));
-    assertEquals(
-        "&#\n",
-        Encoding.decodeHtml("&#&#10;"));
-    assertEquals(
-        "",  // Invalid XML char elided.
-        Encoding.decodeHtml("&#1"));
-    assertEquals(
-        "\t",
-        Encoding.decodeHtml("&#9"));
-    assertEquals(
-        "\n",
-        Encoding.decodeHtml("&#10"));
+    assertDecodedHtml("&#000a;", "&#000a;");
+    assertDecodedHtml("\n", "&#10;");
+    assertDecodedHtml("\n", "&#010;");
+    assertDecodedHtml("\n", "&#0010;");
+    assertDecodedHtml("\t", "&#9;");
+    assertDecodedHtml("\n", "&#10");
+    assertDecodedHtml("&#00ziggy", "&#00ziggy");
+    assertDecodedHtml("&#\n", "&#&#010;");
+    assertDecodedHtml("\n", "&#0&#010;");
+    assertDecodedHtml("\n", "&#01&#10;");
+    assertDecodedHtml("&#\n", "&#&#10;");
+    assertDecodedHtml("", "&#1"); // Invalid XML char elided.
+    assertDecodedHtml("\t", "&#9");
+    assertDecodedHtml("\n", "&#10");
 
     // test the named escapes
-    assertEquals(
-        "<",
-        Encoding.decodeHtml("&lt;"));
-    assertEquals(
-        ">",
-        Encoding.decodeHtml("&gt;"));
-    assertEquals(
-        "\"",
-        Encoding.decodeHtml("&quot;"));
-    assertEquals(
-        "'",
-        Encoding.decodeHtml("&apos;"));
-    assertEquals(
-        "'",
-        Encoding.decodeHtml("&#39;"));
-    assertEquals(
-        "'",
-        Encoding.decodeHtml("&#x27;"));
-    assertEquals(
-        "&",
-        Encoding.decodeHtml("&amp;"));
-    assertEquals(
-        "&lt;",
-        Encoding.decodeHtml("&amp;lt;"));
-    assertEquals(
-        "&",
-        Encoding.decodeHtml("&AMP;"));
-    assertEquals(
-        "&",
-        Encoding.decodeHtml("&AMP"));
-    assertEquals(
-        "&",
-        Encoding.decodeHtml("&AmP;"));
-    assertEquals(
-        "\u0391",
-        Encoding.decodeHtml("&Alpha;"));
-    assertEquals(
-        "\u03b1",
-        Encoding.decodeHtml("&alpha;"));
-    assertEquals(
-        "\ud835\udc9c",  // U+1D49C requires a surrogate pair in UTF-16.
-        Encoding.decodeHtml("&Ascr;"));
-    assertEquals(
-        "fj",  // &fjlig; refers to 2 characters.
-        Encoding.decodeHtml("&fjlig;"));
-    assertEquals(
-        "\u2233",  // HTML entity with the longest name.
-        Encoding.decodeHtml("&CounterClockwiseContourIntegral;"));
-    assertEquals( // Missing the semicolon.
-        "&CounterClockwiseContourIntegral",
-        Encoding.decodeHtml("&CounterClockwiseContourIntegral"));
+    assertDecodedHtml("<", "&lt;");
+    assertDecodedHtml(">", "&gt;");
+    assertDecodedHtml("\"", "&quot;");
+    assertDecodedHtml("'", "&apos;");
+    assertDecodedHtml("'", "&#39;");
+    assertDecodedHtml("'", "&#x27;");
+    assertDecodedHtml("&", "&amp;");
+    assertDecodedHtml("&lt;", "&amp;lt;");
+    assertDecodedHtml("&", "&AMP;");
+    assertDecodedHtml("&", "&AMP");
+    assertDecodedHtml("&", "&AmP;");
+    assertDecodedHtml("\u0391", "&Alpha;");
+    assertDecodedHtml("\u03b1", "&alpha;");
+    // U+1D49C requires a surrogate pair in UTF-16.
+    assertDecodedHtml("\ud835\udc9c", "&Ascr;");
+    // &fjlig; refers to 2 characters.
+    assertDecodedHtml("fj", "&fjlig;");
+    // HTML entity with the longest name.
+    assertDecodedHtml("\u2233", "&CounterClockwiseContourIntegral;");
+    // Missing the semicolon.
+    assertDecodedHtml(
+            "&CounterClockwiseContourIntegral",
+            "&CounterClockwiseContourIntegral"
+    );
 
-    assertEquals(
-        "&;",
-        Encoding.decodeHtml("&;"));
-    assertEquals(
-        "&bogus;",
-        Encoding.decodeHtml("&bogus;"));
+    assertDecodedHtml("&;", "&;");
+    assertDecodedHtml("&bogus;", "&bogus;");
+
+    // Some strings decode differently depending on whether or not they're in an HTML attribute.
+    assertDecodedHtml(
+            "?foo\u00B6m=bar",
+            "?foo&param=bar",
+            "?foo&param=bar"
+    );
+    assertDecodedHtml(
+            "?foo\u00B6=bar",
+            "?foo&para=bar",
+            "?foo&para=bar"
+    );
   }
 
   @Test

--- a/src/test/java/org/owasp/html/HtmlSanitizerTest.java
+++ b/src/test/java/org/owasp/html/HtmlSanitizerTest.java
@@ -440,6 +440,13 @@ public class HtmlSanitizerTest extends TestCase {
     }
   }
 
+  @Test
+  public static final void testIssue254SemicolonlessNamedCharactersInUrls() {
+    String input = "<a href=\"/test/?param1=valueOne&param2=valueTwo\">click me</a>";
+    String want = "<a href=\"/test/?param1&#61;valueOne&amp;param2&#61;valueTwo\">click me</a>";
+    assertEquals(want, sanitize(input));
+  }
+
   private static String sanitize(@Nullable String html) {
     StringBuilder sb = new StringBuilder();
     HtmlStreamRenderer renderer = HtmlStreamRenderer.create(


### PR DESCRIPTION
ZBUG-3867 - hyperlink getting modified. 

Issue - &param is getting replaced with ¶m&#61; in the hyperlink due to which the link is not accessible.

This is a known issue of  OWASP/java-html-sanitizer. This PR has been merged but we haven't took the latest code, due to which we are still facing the issue. 
PR link - https://github.com/OWASP/java-html-sanitizer/issues/254 

Fix- Referred the above PR and did similar changes to fix the issue. 



