### PR TITLE
ZBUG-3640 - fix for OWASP Sanitizer blocking message from displaying …

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,7 @@
  <!-- PROPERTIES -->
  <property file='build-custom.properties' />
  
- <property name='version'   value='20190610.6'/>
+ <property name='version'   value='20190610.7'/>
  <property name='name'      value='owasp-java-html-sanitizer'/>
  <property name='fullname'  value='${name}-${version}'/>
  <property name='Title'     value='OWASP Java HTML Sanitizer'/>

--- a/src/main/java/org/owasp/html/ExtensibleHtmlStreamRenderer.java
+++ b/src/main/java/org/owasp/html/ExtensibleHtmlStreamRenderer.java
@@ -388,7 +388,7 @@ public class ExtensibleHtmlStreamRenderer implements HtmlStreamEventReceiver {
                 }
                 break;
             case '>':
-                if (i >= 2 && sb.charAt(i - 2) == '-' && sb.charAt(i - 2) == '-') {
+                if (i >= 2 && sb.charAt(i - 2) == '-' && sb.charAt(i - 1) == '-') {
                     if (innerStart < 0) {
                         return i - 2;
                     }

--- a/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -341,7 +341,7 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
           }
           break;
         case '>':
-          if (i >= 2 && sb.charAt(i - 2) == '-' && sb.charAt(i - 2) == '-') {
+          if (i >= 2 && sb.charAt(i - 2) == '-' && sb.charAt(i - 1) == '-') {
             if (innerStart < 0) { return i - 2; }
             // Merged start and end like <!--->
             if (innerStart + 6 > i) { return innerStart; }

--- a/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
+++ b/src/test/java/org/owasp/html/HtmlPolicyBuilderTest.java
@@ -994,6 +994,43 @@ public class HtmlPolicyBuilderTest extends TestCase {
     assertEquals("x<textArea>y</textArea>", textAreaPolicy.sanitize(input));
   }
 
+  // Testing CSS Child Combinator between two selector  with case ".hdg-1>._inner"
+  @Test
+  public static final void testCSSChildCombinator() {
+    HtmlPolicyBuilder builder = new HtmlPolicyBuilder();
+
+    PolicyFactory factory = builder.allowElements("span","style","h1").allowTextIn("style","h1")
+            .allowAttributes("type").onElements("style").allowStyling()
+            .toFactory();
+
+
+    String toSanitize = "<style type=\"text/css\">\n"
+            + "<!--\n"
+            + ".hdg-1 {\n"
+            + "width:100%;\n"
+            + "}\n"
+            + "\n"
+            + ".hdg-1>._inner {\n"
+            + "background-color: #999;\n"
+            + "}\n"
+            + "-->\n"
+            + "</style>\n"
+            + "<h1>Test</h1>\n"
+            + "\n"
+            + "<style>\n"
+            + "<!--\n"
+            + ".hdg-1 {\n"
+            + "width:100%;\n"
+            + "}\n"
+            + "\n"
+            + ".hdg-1>._inner {\n"
+            + "background-color: #666;\n"
+            + "}\n"
+            + "-->\n"
+            + "</style>";
+    assertEquals(toSanitize, factory.sanitize(toSanitize));
+  }
+
   private static String apply(HtmlPolicyBuilder b) {
     return apply(b, EXAMPLE);
   }


### PR DESCRIPTION
Problem - OWASP Sanitizer blocking message from displaying in webmail. 

Analysis- While checking for the HTML Comment, it seems to have been checked the previous two characters are  "-" but only char - 2 is checked twice. So if a CSS Child combinator with - selector is used, it was treated as error.

This is a known issue of OWASP/java-html-sanitizer. This PR has been merged but we haven't took the latest code, due to which we are still facing the issue.

PR link - https://github.com/OWASP/java-html-sanitizer/pull/297

Fix- Referred the above PR and did similar changes to fix the issue.